### PR TITLE
feat(_validate_start_time): Adding a if statment to the to start_time…

### DIFF
--- a/audio_extract/validators.py
+++ b/audio_extract/validators.py
@@ -76,6 +76,9 @@ class AudioExtractValidator:
     def _validate_start_time(self):
         start_time = self.start_time
 
+        if start_time == "00:00:00":
+            return
+
         pattern = r"^(?:(\d{1,2}):)?(\d{1,2}):(\d{1,2})$"
         if not re.match(pattern, start_time):
             raise Exception("Invalid time format. Must be in HH:MM:SS or MM:SS format.")


### PR DESCRIPTION
… to avoid validating when there is a dault value, since there is no needance to to with the value is 0

Hi, open this PR to add new validator in the start_time_valdiator, 


Did this becouse of a bug with mutagen at ->

def media_duration(file_path: str):
    file = mutagen.File(file_path)
    duration = file.info.length
    return duration
    
   the script  is crashing due to duration returning none, 


i noticed that we can avoid this bug just to avoid validitng when the start time is 0