### PR TITLE
fix the function that determines the duration of the video file

### DIFF
--- a/audio_extract/utils.py
+++ b/audio_extract/utils.py
@@ -1,9 +1,9 @@
-import mutagen
+import ffmpeg
 
 
 def media_duration(file_path: str):
-    file = mutagen.File(file_path)
-    duration = file.info.length
+    probe = ffmpeg.probe(file_path)
+    duration = float(probe['format']['duration'])
     return duration
 
 


### PR DESCRIPTION
Previous version contained a function media_duration(file_path: str) that worked only for audio files. If the input file is mp4 video, the duration was 0. This hindered the basic used of the library described on the pypi.org "Extract sub clip audio with custom duration".