### PR TITLE
Update package requirements to use minimum versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,9 @@ class AddToPathCommand(Command):
 
 
 requires = [
-    "ffmpeg-python==0.2.0",
-    "imageio-ffmpeg==0.4.8",
-    "mutagen==1.46.0"
+    "ffmpeg-python>=0.2.0",
+    "imageio-ffmpeg>=0.4.8",
+    "mutagen>=1.46.0"
 ]
 
 long_description = open('README.md').read()


### PR DESCRIPTION
Fixes #7 
Allows higher package versions as dependencies, like it uses to be before 0.4.0 (see blame).

No AI was used in the making.